### PR TITLE
HornetQ link is wrong

### DIFF
--- a/index.html.haml
+++ b/index.html.haml
@@ -17,7 +17,7 @@ inhibit_title: true
 
     The services backed by the libraries include
     [Undertow](http://undertow.io) for web,
-    [HornetQ](http://hornetq.org) for messaging,
+    [HornetQ](http://hornetq.jboss.org/) for messaging,
     [Infinispan](http://infinispan.org) for caching,
     [Narayana](http://www.jboss.org/narayana) for transactions, and
     [Quartz](http://quartz-scheduler.org) for scheduling.


### PR DESCRIPTION
The old link redirects to the JBoss forums, instead of the index page of the project
